### PR TITLE
Fix Lighthouse Best Practices: Update CSP for Google Tag Manager

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 // You might need to insert additional domains in script-src if you are using external services
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is embeds.beehiiv.com gc.zgo.at googletagmanager.com;
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' giscus.app analytics.umami.is embeds.beehiiv.com gc.zgo.at googletagmanager.com www.googletagmanager.com;
   style-src 'self' 'unsafe-inline';
   img-src * blob: data:;
   media-src *.s3.amazonaws.com;


### PR DESCRIPTION
## Summary
- Updates Content Security Policy to allow Google Tag Manager scripts from `www.googletagmanager.com`
- Resolves Lighthouse Best Practices issues that were causing a score of 75
- Eliminates browser console errors related to blocked GTM scripts

## Changes
- Added `www.googletagmanager.com` to the `script-src` directive in `next.config.js`
- This allows GTM to load from both the main domain and www subdomain

## Test plan
- [ ] Deploy changes to staging/preview environment
- [ ] Run Lighthouse audit to verify Best Practices score improves to 100
- [ ] Verify GTM scripts load without CSP violations
- [ ] Check browser console for elimination of previous errors

🤖 Generated with [Claude Code](https://claude.ai/code)