### PR TITLE
fix: prevent horizontal scroll from images on mobile devices

### DIFF
--- a/components/Image.tsx
+++ b/components/Image.tsx
@@ -2,7 +2,7 @@ import NextImage, { ImageProps } from 'next/image'
 
 const Image = ({ width, height, ...rest }: ImageProps) => (
   <NextImage
-    className="mx-auto max-h-96 max-w-[672px] rounded-lg object-contain"
+    className="mx-auto max-h-96 w-full max-w-full rounded-lg object-contain sm:max-w-[672px]"
     width={width || 672}
     height={height || 384}
     {...rest}

--- a/components/SectionContainer.tsx
+++ b/components/SectionContainer.tsx
@@ -6,6 +6,8 @@ interface Props {
 
 export default function SectionContainer({ children }: Props) {
   return (
-    <section className="mx-auto max-w-3xl px-4 sm:px-6 xl:max-w-5xl xl:px-0">{children}</section>
+    <section className="mx-auto max-w-3xl overflow-x-hidden px-4 sm:px-6 xl:max-w-5xl xl:px-0">
+      {children}
+    </section>
   )
 }

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -60,7 +60,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
           )}
           <div className="grid-rows-[auto_1fr] divide-y divide-gray-200 pb-8 dark:divide-gray-700 xl:gap-x-6 xl:divide-y-0">
             <div className="divide-y divide-gray-200 dark:divide-gray-700 xl:col-span-3 xl:row-span-2 xl:pb-0">
-              <div className="prose prose-stone max-w-none pb-8 pt-10 text-justify dark:prose-invert">
+              <div className="prose prose-stone max-w-none overflow-x-hidden pb-8 pt-10 text-justify dark:prose-invert">
                 {children}
               </div>
             </div>


### PR DESCRIPTION
- Add overflow-x-hidden to SectionContainer to prevent page-level overflow
- Add overflow-x-hidden to prose container in PostLayout for content-level control
- Update Image component with mobile-first responsive classes (w-full max-w-full sm:max-w-[672px])
- Maintain desktop layout while fixing mobile image centering and overflow issues

🤖 Generated with [Claude Code](https://claude.ai/code)