### PR TITLE
feat: update light mode to warm cream/ivory background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,7 +66,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     >
       <link rel="icon" href="/static/favicons/favicon.ico" type="image/x-icon" />
       <meta name="msapplication-TileColor" content="#000000" />
-      <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fefefe" />
+      <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fefdfb" />
       <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f172a" />
       <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       <body className="bg-gradient-mesh bg-gradient-subtle text-slate-900 antialiased transition-all duration-500 dark:bg-gradient-mesh-dark dark:bg-gradient-subtle-dark dark:text-slate-100">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -79,18 +79,18 @@ module.exports = {
         },
         gray: colors.slate,
         background: {
-          light: '#fefefe',
+          light: '#fefdfb',
           dark: '#0f172a',
         },
         surface: {
-          light: '#f8fafc',
+          light: '#fbf9f6',
           dark: '#1e293b',
         },
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-        'gradient-subtle': 'linear-gradient(135deg, #fefefe 0%, #f8fafc 40%, #f1f5f9 100%)',
+        'gradient-subtle': 'linear-gradient(135deg, #fefdfb 0%, #fbf9f6 40%, #f7f5f1 100%)',
         'gradient-subtle-dark': 'linear-gradient(135deg, #0f172a 0%, #1e293b 40%, #334155 100%)',
         'gradient-mesh': `
           radial-gradient(at 40% 20%, hsla(28,100%,74%,0.05) 0px, transparent 50%),


### PR DESCRIPTION
## Summary
- Updates light mode background from pure white to professional warm cream/ivory tones
- Changes background colors: `#fefefe` → `#fefdfb` and surface colors: `#f8fafc` → `#fbf9f6`
- Adjusts gradient to use warm cream color progression for visual warmth
- Updates meta theme-color to match new background scheme

## Test plan
- [x] Verify development server runs without errors
- [x] Check gradient transitions work smoothly
- [x] Ensure text contrast remains accessible
- [x] Confirm linting passes
- [x] Test color scheme maintains professional appearance

🤖 Generated with [Claude Code](https://claude.ai/code)