### PR TITLE
Add location to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export default async function Home() {
   const avatar = '/static/images/arjun.webp'
   const occupation = 'Senior Director of Engineering'
   const company = 'StubHub'
+  const location = 'Brooklyn, New York'
   const twitter = 'https://twitter.com/raoarjun'
   const linkedin = 'https://www.linkedin.com/in/arjunrao87/'
   const github = 'https://github.com/arjunrao87'
@@ -56,6 +57,9 @@ export default async function Home() {
               >
                 {company}
               </a>
+            </div>
+            <div className="prose prose-stone text-lg font-medium text-slate-600 dark:prose-invert dark:text-slate-400">
+              📍 {location}
             </div>
             <div className="flex space-x-3 pt-6">
               <SocialIcon kind="github" href={github} />


### PR DESCRIPTION
Adds "Brooklyn, New York" location to the home page as requested in issue #21.

Changes:
- Added location variable and display with location pin emoji
- Positioned after company information in personal info section
- Consistent styling with existing design

Fixes #21

Generated with [Claude Code](https://claude.ai/code)